### PR TITLE
Replace os._exit with clean exits in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import pytest
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Handle session teardown and optional forced exit."""
+    env_force_exit = os.getenv("PYTEST_FORCE_EXIT")
+    if env_force_exit:
+        if env_force_exit.lower() in {"1", "true", "yes"}:
+            # Prefer pytest.exit for a clean teardown
+            pytest.exit("forced exit", returncode=exitstatus)
+        elif env_force_exit.lower() in {"sys"}:
+            # Use sys.exit explicitly when requested
+            sys.exit(exitstatus)
+


### PR DESCRIPTION
## Summary
- add `tests/conftest.py` to handle optional forced exits
- use `pytest.exit` or `sys.exit` based on `PYTEST_FORCE_EXIT` environment variable

## Testing
- `ruff check .`
- `pytest -q` *(fails: module `src.focus_steps_view` import error and blocked network access)*

------
https://chatgpt.com/codex/tasks/task_b_687cdff285888326843ffc596cabe817