### PR TITLE
Fix: Adhan playback and focus steps display (#4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           - os: windows-latest
             python-version: '3.10'
             asset_name: prayer-player-windows.exe
-            asset_path: deployment/windows/Output/*.exe
+            asset_path: dist/PrayerPlayer/*.exe
 
     runs-on: ${{ matrix.os }}
 
@@ -92,7 +92,7 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           # Run the application directly with dry run arguments
-          & .\dist\PrayerPlayer.exe --dry-run --country "Germany" --city "Deggendorf" || true
+          & .\dist\PrayerPlayer\PrayerPlayer.exe --dry-run --country "Germany" --city "Deggendorf" || true
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ Installers/prayer-player-ubuntu.zip
 Installers/prayer-player-windows.zip
 prayer-player-deb-staging/
 erros.txt
+improvements.md
+err.txt

--- a/improvements.md
+++ b/improvements.md
@@ -1,37 +1,58 @@
-Work Plan: Architectural Refactoring
+### Extended Existing Features:
 
-  Phase 1: Enhance Testability (Critical Priority)
-   * Goal: Decouple business logic from the UI to eliminate testing-related segmentation faults and enable reliable, independent testing of core logic.
-   * Tasks:
-       1. Refactor `focus_steps.py`:
-           * I will create a new FocusStepsPresenter class to contain the core logic for managing steps, content, and state.
-           * The existing StepWindow in gui.py will be refactored into a thin "View" component, responsible only for displaying the state managed by
-             the presenter and forwarding user events to it.
-       2. Refactor `scheduler.py`:
-           * I will analyze the scheduler's methods to identify logic that is tightly coupled to the GUI.
-           * This logic will be extracted into separate, testable components, leaving the scheduler's methods as minimal wrappers.
-       3. Create Unit Tests:
-           * I will write new pytest tests for the FocusStepsPresenter and other extracted components. These tests will be pure Python, with no Qt
-             dependencies, ensuring they are fast and stable.
+**1. Reconfigure Prayer Time on Location Change**
 
-  Phase 2: Dependency Injection & Configuration Management
-   * Goal: Reduce coupling, improve modularity, and make configuration safer and more robust.
-   * Tasks:
-       1. Introduce Dependency Injection (DI):
-           * I will modify component constructors (like PrayerScheduler) to accept their dependencies (like audio players or calendar services) as
-             arguments, instead of relying on global accessors.
-           * A central "Composition Root" will be established in src/__main__.py to instantiate and connect all major application components.
-       2. Enhance Configuration:
-           * I will add pydantic to the project to define a clear configuration schema, ensuring all loaded settings are valid.
-           * The configuration system will be updated to load sensitive data (e.g., API keys) from environment variables first, falling back to
-             file-based configuration only if necessary.
+*   **Extended Description:** When the user's geographical location changes, the application should automatically or manually reconfigure prayer times and associated calendar events/scheduling to reflect the new location's timings. This ensures the accuracy and relevance of prayer notifications and calendar entries.
+*   **Technical Steps:**
+    1.  **Location Detection:** Implement a mechanism to detect changes in the user's location (e.g., using IP-based geolocation, system location services if available, or manual input via settings).
+    2.  **Trigger Reconfiguration:** Upon detecting a significant location change, prompt the user for confirmation to update prayer times.
+    3.  **Prayer Time Calculation:** Recalculate prayer times using the new location's coordinates (latitude, longitude) and the user's chosen calculation method (e.g., ISNA, MWL).
+    4.  **Calendar Update:** Update existing prayer time entries in the integrated calendar (e.g., Google Calendar) with the new timings. This may involve deleting old events and creating new ones.
+    5.  **Scheduler Adjustment:** Adjust the internal scheduler (`scheduler.py`) to trigger notifications and actions based on the newly calculated prayer times.
+    6.  **User Notification:** Inform the user about the successful update of prayer times and scheduling.
+*   **Related Modules:**
+    *   `src/prayer_times.py`: For prayer time calculation.
+    *   `src/calendar_api/google_calendar.py`: For interacting with Google Calendar.
+    *   `src/scheduler.py`: For managing scheduled events and notifications.
+    *   `src/gui.py` / `src/tray_icon.py`: For user prompts and notifications.
+    *   `src/state.py`: To store and retrieve user's location and prayer time settings.
+    *   `src/config/schema.py`: To define location-related settings.
 
-  Phase 3: Error Handling & Concurrency
-   * Goal: Make the application more resilient to failures and clarify its concurrency model.
-   * Tasks:
-       1. Implement Robust Error Handling:
-           * I will establish a global exception handler for the QApplication to catch, log, and report any uncaught errors gracefully.
-           * I will define and use custom exception types (e.g., CalendarSyncError) for more precise error handling.
-       2. Clarify Threading Model:
-           * I will review all background operations to ensure any code that updates the GUI is correctly and safely executed on the main Qt thread.
-           * I will add documentation to clarify the application's threading strategy for future development.
+**2. Prompt for Calendar Integration if `token.json` is Missing**
+
+*   **Extended Description:** If the `token.json` file (which stores Google API authentication tokens) is not found, the application should gracefully inform the user that calendar integration features are unavailable. It should then offer the user the option to authenticate and enable calendar integration, explaining the benefits (e.g., automatic prayer time events in their personal calendar).
+*   **Technical Steps:**
+    1.  **Check for `token.json`:** At application startup or when calendar features are accessed, verify the existence of `token.json`.
+    2.  **Prompt User:** If `token.json` is missing, display a clear and user-friendly dialog box (`gui.py`) asking if they want to enable calendar integration.
+    3.  **Explain Benefits:** Briefly explain the advantages of calendar integration (e.g., "Sync prayer times to your Google Calendar," "Get reminders directly in your calendar").
+    4.  **Initiate Authentication Flow:** If the user agrees, initiate the Google OAuth 2.0 authentication flow (`src/auth/google_auth.py`) to obtain the necessary tokens.
+    5.  **Handle Authentication Success/Failure:**
+        *   On success, save the `token.json` file and enable calendar features.
+        *   On failure, inform the user and allow them to retry or proceed without calendar integration.
+    6.  **Update UI:** Reflect the calendar integration status in the application's UI.
+*   **Related Modules:**
+    *   `src/auth/google_auth.py`: Handles Google OAuth authentication and token management.
+    *   `src/auth/auth_manager.py`: Manages authentication state.
+    *   `src/gui.py`: For displaying prompts and dialogs.
+    *   `src/calendar_api/google_calendar.py`: Relies on `token.json` for API calls.
+
+### Suggested Other Important Features:
+
+**1. Customizable Adhan/Notification Sounds**
+
+*   **Description:** Allow users to select custom audio files (MP3, WAV) for Adhan and other prayer time notifications, providing a more personalized experience.
+*   **Technical Steps:**
+    *   Add a setting in the UI for users to browse and select audio files from their local system.
+    *   Store the path to the custom audio file in the application's configuration.
+    *   Modify the notification system to play the custom audio file if one is set; otherwise, fall back to the default sounds.
+*   **Related Modules:** `src/gui.py`, `src/config/schema.py`, `src/scheduler.py`, `src/assets/`.
+
+**4. Multi-language Support**
+
+*   **Description:** Enable the application's interface and notifications to be displayed in multiple languages, broadening its accessibility and user base.
+*   **Technical Steps:**
+    *   Implement an internationalization (i18n) framework (e.g., `gettext` for Python/Qt's built-in i18n).
+    *   Externalize all user-facing strings into translation files.
+    *   Provide a language selection option in the settings.
+    *   Translate the strings into desired languages.
+*   **Related Modules:** `src/gui.py`, `src/config/schema.py`, and potentially new localization files/directories.

--- a/src/actions.py
+++ b/src/actions.py
@@ -4,6 +4,8 @@
 import os
 import subprocess
 import sys
+import tempfile # Add this import
+from importlib import resources # Add this import
 
 from src.config.security import LOG
 from src.qt_utils import run_in_qt_thread
@@ -56,14 +58,33 @@ def play(audio_path: str) -> None:
     Plays the given audio file using a suitable method for the current platform.
     This is a blocking call.
     """
-    if not os.path.exists(audio_path):
-        LOG.error(f"Audio file not found: {audio_path}")
+    effective_audio_path = audio_path
+
+    # If running in a PyInstaller bundle and the audio_path doesn't exist,
+    # it might be a bundled resource that needs to be extracted to a temporary file.
+    if getattr(sys, 'frozen', False) and not os.path.exists(audio_path):
+        try:
+            # Read the binary content of the default adhan.wav from the package
+            audio_content = resources.read_binary('assets', 'adhan.wav')
+            
+            # Create a temporary file and write the content to it
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_audio_file:
+                temp_audio_file.write(audio_content)
+                effective_audio_path = temp_audio_file.name
+            
+            LOG.info(f"Extracted bundled adhan.wav to temporary file: {effective_audio_path}")
+        except Exception as e:
+            LOG.error(f"Error extracting bundled adhan.wav: {e}")
+            effective_audio_path = None # Indicate failure to get a valid path
+
+    if not effective_audio_path or not os.path.exists(effective_audio_path):
+        LOG.error(f"Audio file not found: {audio_path} (effective: {effective_audio_path})")
         return
 
     if sys.platform.startswith('linux'):
-        LOG.info(f"📢 Attempting to play audio using 'aplay': {audio_path}")
+        LOG.info(f"📢 Attempting to play audio using 'aplay': {effective_audio_path}")
         try:
-            subprocess.run(['aplay', audio_path], check=True)
+            subprocess.run(['aplay', effective_audio_path], check=True)
             LOG.info("Playback finished successfully via 'aplay'.")
         except subprocess.CalledProcessError as e:
             LOG.error(f"aplay failed with error: {e}")
@@ -74,9 +95,17 @@ def play(audio_path: str) -> None:
     else:
         # Fallback to playsound for other platforms (macOS, Windows)
         from playsound import playsound
-        LOG.info(f"📢 Attempting to play audio using 'playsound': {audio_path}")
+        LOG.info(f"📢 Attempting to play audio using 'playsound': {effective_audio_path}")
         try:
-            playsound(audio_path)
+            playsound(effective_audio_path)
             LOG.info("Playback finished successfully via 'playsound'.")
         except Exception as e:
             LOG.error(f"An unexpected error occurred during playsound execution: {e}")
+
+    # Clean up the temporary file if it was created
+    if effective_audio_path != audio_path and os.path.exists(effective_audio_path):
+        try:
+            os.remove(effective_audio_path)
+            LOG.info(f"Cleaned up temporary audio file: {effective_audio_path}")
+        except Exception as e:
+            LOG.warning(f"Could not remove temporary audio file {effective_audio_path}: {e}")

--- a/src/presenter/focus_steps_presenter.py
+++ b/src/presenter/focus_steps_presenter.py
@@ -2,6 +2,8 @@
 
 import re
 import random
+import os
+import sys
 from importlib import resources
 
 def load_steps_from_file(file_path):
@@ -40,7 +42,12 @@ def load_steps_from_file(file_path):
     
     return steps
 
-STEPS_FILE_PATH = str(resources.files('config').joinpath('steps_content.txt'))
+if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+    # Running in a PyInstaller bundle
+    STEPS_FILE_PATH = os.path.join(sys._MEIPASS, 'config', 'steps_content.txt')
+else:
+    # Running in a normal Python environment
+    STEPS_FILE_PATH = str(resources.files('src.config').joinpath('steps_content.txt'))
 STEPS = load_steps_from_file(STEPS_FILE_PATH)
 
 class FocusStepsPresenter:

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -98,8 +98,15 @@ class PrayerScheduler:
         self.state_manager.state = AppState.PRAYER_TIME
         
         try:
-            self.action_executor.play_audio(self.audio_path)
-            LOG.info("Audio finished.")
+            from src.config.security import get_asset_path
+            adhan_path = str(get_asset_path('adhan.wav'))
+            duaa_path = str(get_asset_path('duaa_after_adhan.wav'))
+
+            LOG.info(f"Playing Adhan from {adhan_path}")
+            self.action_executor.play_audio(adhan_path)
+            LOG.info("Adhan finished. Playing Duaa.")
+            self.action_executor.play_audio(duaa_path)
+            LOG.info("Duaa finished.")
 
         except Exception as e:
             LOG.error(f"Error during audio playback or focus mode trigger: {e}")

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -45,7 +45,7 @@ class TestActions(unittest.TestCase):
         non_existent_file = "non_existent_file.wav"
         with patch('src.actions.LOG') as mock_log:
             play(non_existent_file)
-            mock_log.error.assert_called_with(f"Audio file not found: {non_existent_file}")
+            mock_log.error.assert_called_with(f"Audio file not found: {non_existent_file} (effective: {non_existent_file})")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -60,8 +60,16 @@ class TestPrayerScheduler(unittest.TestCase):
         self.assertEqual(len(self.scheduler.scheduler.get_jobs()), 3)
 
     def test_play_adhan_and_duaa(self):
+        from unittest.mock import call
+        from src.config.security import get_asset_path
+
         self.scheduler.play_adhan_and_duaa()
-        self.action_executor.play_audio.assert_called_once_with(self.audio_path)
+
+        expected_calls = [
+            call(str(get_asset_path('adhan.wav'))),
+            call(str(get_asset_path('duaa_after_adhan.wav')))
+        ]
+        self.action_executor.play_audio.assert_has_calls(expected_calls)
         self.assertEqual(self.state_manager.state, AppState.IDLE)
 
     def test_schedule_single_prayer_job(self):


### PR DESCRIPTION
* Fix: Adhan playback and focus steps display

- Modified scheduler.py to play both adhan.wav and duaa_after_adhan.wav sequentially.
- Corrected focus_steps_presenter.py to properly locate steps_content.txt in both development and PyInstaller bundled environments.
- Updated improvements.md with extended feature descriptions and new suggestions.

* Fix: Linting errors in focus_steps_presenter.py and Windows dry run path

- Moved  to the top of  to resolve E402 and F811 linting errors.
- Corrected the path for the Windows dry run executable in  from  to .

* 1 Fix: Correct Windows build paths in CI workflow 2 3 Updated .github/workflows/build.yml to use the correct paths for the 4 Windows executable in both artifact uploads and dry-run commands. 5 This resolves the "file not recognized" error during the Windows build 6 dry run.

* Fix: Correct Windows build paths and audio file loading

- Updated .github/workflows/build.yml to use the correct paths for the Windows executable in both artifact uploads and dry-run commands. This resolves the "file not recognized" error during the Windows build dry run.
- Modified play() function in src/actions.py to correctly handle bundled audio files by extracting them to a temporary location if the application is running in a PyInstaller bundle, addressing the "Audio file not found" error.
- Updated test_actions.py to reflect the new logging format.

* Fix: Resolve ruff E402 errors in src/actions.py

Moved module-level imports to the top of the file to comply with Ruff E402 rule.